### PR TITLE
Fix avatar alt text

### DIFF
--- a/script.js
+++ b/script.js
@@ -1073,6 +1073,7 @@
     } else {
       profileAvatar.src = 'icons/default-avatar.svg';
     }
+    profileAvatar.alt = 'Avatar for ' + name;
     profileAvatar.style.display = 'inline-block';
     const currentUser = localStorage.getItem(currentUserKey);
     const canEdit = currentUser === name || adminUsers.includes(currentUser);


### PR DESCRIPTION
## Summary
- assign alt attribute for profile avatars in JS so it's dynamically set
- keep default alt text empty in `index.html`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_688afb8c7b3c8325a61c1f128e22f89c