### PR TITLE
Add icons to sidebar and style alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,15 +36,15 @@
     <div class="logo">Family Nest 🪺</div>
     <input type="search" id="sidebarSearch" placeholder="Search menu" aria-label="Search navigation menu" autocomplete="off"/>
     <ul role="menubar" aria-orientation="vertical" id="sidebarMenu">
-      <li role="menuitem" tabindex="0" class="active" aria-current="page">Wall</li>
-      <li role="menuitem" tabindex="-1">Q&A</li>
-      <li role="menuitem" tabindex="-1">Calendar</li>
-      <li role="menuitem" tabindex="-1">Chores</li>
-      <li role="menuitem" tabindex="-1">Scoreboard</li>
-      <li role="menuitem" tabindex="-1">Ghassan</li>
-      <li role="menuitem" tabindex="-1">Mariem</li>
-      <li role="menuitem" tabindex="-1">Yazid</li>
-      <li role="menuitem" tabindex="-1">Yahya</li>
+      <li role="menuitem" tabindex="0" class="active" aria-current="page"><i class="fa-solid fa-house"></i><span>Wall</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-circle-question"></i><span>Q&amp;A</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-calendar-days"></i><span>Calendar</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-broom"></i><span>Chores</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-trophy"></i><span>Scoreboard</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-user"></i><span>Ghassan</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-user"></i><span>Mariem</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-user"></i><span>Yazid</span></li>
+      <li role="menuitem" tabindex="-1"><i class="fa-solid fa-user"></i><span>Yahya</span></li>
     </ul>
     <button id="changeUserBtn" class="btn-secondary" aria-label="Change User">Switch User</button>
   </nav>

--- a/style.css
+++ b/style.css
@@ -92,6 +92,14 @@ nav.sidebar li {
   transition: background-color 0.3s ease, color 0.3s ease;
   user-select: none;
 }
+nav.sidebar li i {
+  width: 20px;
+  text-align: center;
+  font-size: 1.1rem;
+}
+nav.sidebar li span {
+  flex: 1;
+}
 nav.sidebar li:hover {
   background: var(--color-primary);
   color: white;


### PR DESCRIPTION
## Summary
- add FontAwesome icons before sidebar labels
- style sidebar list items so icons and text align correctly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688afebd93fc832589cba23ee6183a8a