### PR TITLE
Add card layout wrappers

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,37 +72,42 @@
 
     <!-- Wall Section -->
     <section id="wall" aria-label="Wall Section">
-      <h1>Wall</h1>
-      <textarea id="newWallPost" placeholder="Write something..." rows="3" aria-label="New wall post" ></textarea>
-      <br/>
-      <button class="add-btn" id="addWallPostBtn">Post</button>
-      <ul class="wall-posts" aria-live="polite" aria-atomic="true" aria-relevant="additions" id="wallPostsList"></ul>
+      <div class="card">
+        <h1>Wall</h1>
+        <textarea id="newWallPost" placeholder="Write something..." rows="3" aria-label="New wall post"></textarea>
+        <br/>
+        <button class="add-btn" id="addWallPostBtn">Post</button>
+        <ul class="wall-posts" aria-live="polite" aria-atomic="true" aria-relevant="additions" id="wallPostsList"></ul>
+      </div>
     </section>
 
     <!-- Q&A Section -->
     <section id="qa" aria-label="Q&A Section" hidden>
-      <h1>Q&A</h1>
-      <ul class="qa-list" aria-live="polite" aria-atomic="true" id="qaList"></ul>
-      <input type="text" id="newQuestion" placeholder="Ask a question..." aria-label="New question input" autocomplete="off"/>
-      <button class="add-btn" id="askBtn">Ask</button>
+      <div class="card">
+        <h1>Q&A</h1>
+        <ul class="qa-list" aria-live="polite" aria-atomic="true" id="qaList"></ul>
+        <input type="text" id="newQuestion" placeholder="Ask a question..." aria-label="New question input" autocomplete="off"/>
+        <button class="add-btn" id="askBtn">Ask</button>
 
-      <div id="adminAnswerSection" hidden aria-live="polite" aria-atomic="true">
-        <h2>Answer a Question</h2>
-        <select id="questionSelect" aria-label="Select question to answer"></select>
-        <textarea id="answerInput" rows="3" placeholder="Type answer here..." aria-label="Answer input"></textarea>
-        <button id="saveAnswerBtn" class="add-btn">Save Answer</button>
-      </div>
+        <div id="adminAnswerSection" hidden aria-live="polite" aria-atomic="true">
+          <h2>Answer a Question</h2>
+          <select id="questionSelect" aria-label="Select question to answer"></select>
+          <textarea id="answerInput" rows="3" placeholder="Type answer here..." aria-label="Answer input"></textarea>
+          <button id="saveAnswerBtn" class="add-btn">Save Answer</button>
+        </div>
 
-      <div id="pinnedMessage" class="pinned-message" aria-live="polite" aria-atomic="true">
-        Mariem is the love of my life and followed by Yazid and Yahya. You are my kids and you are my whole world, the best time I spend is with all of you.
+        <div id="pinnedMessage" class="pinned-message" aria-live="polite" aria-atomic="true">
+          Mariem is the love of my life and followed by Yazid and Yahya. You are my kids and you are my whole world, the best time I spend is with all of you.
+        </div>
       </div>
     </section>
 
     <!-- Calendar Section -->
     <section id="calendar" aria-label="Calendar Section" hidden>
-      <h1>Calendar</h1>
+      <div class="card">
+        <h1>Calendar</h1>
 
-      <table id="calendarTable" aria-label="August 2025 Calendar" role="grid" aria-readonly="true" aria-describedby="calendarLegend">
+        <table id="calendarTable" aria-label="August 2025 Calendar" role="grid" aria-readonly="true" aria-describedby="calendarLegend">
         <thead>
           <tr>
             <th scope="col" style="padding: 6px; border: 1px solid #ddd;">Sun</th>
@@ -136,35 +141,38 @@
       <label for="eventDesc">Event Description:</label><br/>
       <input type="text" id="eventDesc" placeholder="Description" aria-label="Event description" autocomplete="off" />
       <br/>
-      <button class="add-btn" id="addEventBtn">Add Event</button>
+        <button class="add-btn" id="addEventBtn">Add Event</button>
+      </div>
     </section>
 
     <!-- Chores Section -->
     <section id="chores" aria-label="Chores Section" hidden>
-      <h1>Chores</h1>
-      <label><input type="checkbox" id="showDailyOnly" /> Show daily chores only</label>
-      <ul id="choresList" class="chores-list" aria-live="polite" aria-atomic="true"></ul>
-      <!-- Admin-only chore creation form -->
-      <div id="choreAdminPanel" hidden>
-        <h2>Add Chore</h2>
-        <label for="choreDesc">Description:</label><br/>
-        <input type="text" id="choreDesc" placeholder="e.g., Water the plants" aria-label="Chore description" autocomplete="off" />
-        <br/>
-        <label for="choreAssignedTo">Assign To:</label><br/>
-        <select id="choreAssignedTo" aria-label="Assign chore">
-          <option value="All">All</option>
-          <option value="Ghassan">Ghassan</option>
-          <option value="Mariem">Mariem</option>
-          <option value="Yazid">Yazid</option>
-          <option value="Yahya">Yahya</option>
-        </select>
-        <br/>
-        <label for="choreDue">Due Date:</label><br/>
-        <input type="date" id="choreDue" aria-label="Chore due date" />
-        <br/>
-        <label><input type="checkbox" id="choreDaily" /> Daily chore</label>
-        <br/>
-        <button class="add-btn" id="addChoreBtn">Add Chore</button>
+      <div class="card">
+        <h1>Chores</h1>
+        <label><input type="checkbox" id="showDailyOnly" /> Show daily chores only</label>
+        <ul id="choresList" class="chores-list" aria-live="polite" aria-atomic="true"></ul>
+        <!-- Admin-only chore creation form -->
+        <div id="choreAdminPanel" hidden>
+          <h2>Add Chore</h2>
+          <label for="choreDesc">Description:</label><br/>
+          <input type="text" id="choreDesc" placeholder="e.g., Water the plants" aria-label="Chore description" autocomplete="off" />
+          <br/>
+          <label for="choreAssignedTo">Assign To:</label><br/>
+          <select id="choreAssignedTo" aria-label="Assign chore">
+            <option value="All">All</option>
+            <option value="Ghassan">Ghassan</option>
+            <option value="Mariem">Mariem</option>
+            <option value="Yazid">Yazid</option>
+            <option value="Yahya">Yahya</option>
+          </select>
+          <br/>
+          <label for="choreDue">Due Date:</label><br/>
+          <input type="date" id="choreDue" aria-label="Chore due date" />
+          <br/>
+          <label><input type="checkbox" id="choreDaily" /> Daily chore</label>
+          <br/>
+          <button class="add-btn" id="addChoreBtn">Add Chore</button>
+        </div>
       </div>
     </section>
 
@@ -182,6 +190,7 @@
       </h1>
       <button id="editProfileBtn" class="btn-secondary">Edit Profile</button>
       <form id="profileEditForm" class="profile-edit-form" hidden>
+        <div class="card">
         <div class="profile-field">
           <label for="editBirthdate">Birthdate</label>
           <input type="date" id="editBirthdate" />
@@ -224,6 +233,7 @@
         </div>
         <button type="button" id="saveProfileBtn" class="btn-primary">Save</button>
         <button type="button" id="cancelProfileBtn" class="btn-secondary">Cancel</button>
+        </div>
       </form>
       <div id="profileContainer" class="profile-container"></div>
       <div id="similarityInfo" class="similarity-info" hidden></div>

--- a/style.css
+++ b/style.css
@@ -26,6 +26,13 @@
 * {
   box-sizing: border-box;
 }
+.card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
 body, html {
   margin: 0; padding: 0;
   font-family: 'Nunito', sans-serif;
@@ -588,12 +595,15 @@ ul.chores-list li button {
   margin-right: 0.3rem;
 }
 
-input[type="text"], input[type="date"], textarea {
+input[type="text"],
+input[type="date"],
+select,
+textarea {
   padding: 0.5rem 1rem;
   border-radius: 12px;
   border: 1px solid #ddd;
   font-size: 1rem;
-  margin-top: 0.5rem;
+  margin: 0.5rem 0;
   width: 100%;
   max-width: 350px;
   outline: none;
@@ -608,7 +618,7 @@ input[type="text"]:focus, input[type="date"]:focus, textarea:focus {
 }
 
 button.add-btn {
-  margin-top: 1rem;
+  margin: 1rem 0 0.5rem;
   background: var(--color-primary);
   border: none;
   border-radius: 40px;
@@ -634,7 +644,7 @@ button.btn-primary {
   cursor: pointer;
   user-select: none;
   transition: background-color 0.3s ease;
-  margin-top: 1rem;
+  margin: 1rem 0 0.5rem;
 }
 
 button.btn-primary:hover {
@@ -651,7 +661,7 @@ button.btn-secondary {
   cursor: pointer;
   user-select: none;
   transition: background-color 0.3s ease;
-  margin-top: 0.5rem;
+  margin: 0.5rem 0;
 }
 
 button.btn-secondary:hover {


### PR DESCRIPTION
## Summary
- add reusable `.card` class with border radius and padding
- space out inputs and buttons
- wrap Wall, Q&A, Calendar, Chores, and Profile form sections in `.card` containers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688afec41c5c8325be90200a10f04091