### PR TITLE
Add responsive bottom nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,18 @@
     </section>
   </main>
 
+  <nav class="bottom-nav" aria-label="Bottom navigation">
+    <button>Wall</button>
+    <button>Q&A</button>
+    <button>Calendar</button>
+    <button>Chores</button>
+    <button>Scoreboard</button>
+    <button>Ghassan</button>
+    <button>Mariem</button>
+    <button>Yazid</button>
+    <button>Yahya</button>
+  </nav>
+
   <!-- Use a relative path for the script to ensure it loads correctly when deployed in a subdirectory -->
   <script src="./script.js" defer></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -8,8 +8,10 @@
   const currentUserDisplay = document.getElementById('currentUserDisplay');
   const changeUserBtn = document.getElementById('changeUserBtn');
 
-  const tabs = Array.from(document.querySelectorAll('nav.sidebar li'));
+  const sidebarTabs = Array.from(document.querySelectorAll('nav.sidebar li'));
+  const bottomTabs = Array.from(document.querySelectorAll('nav.bottom-nav button'));
   const sections = Array.from(document.querySelectorAll('main.content > section'));
+  const tabCount = sidebarTabs.length;
 
   const sidebarSearch = document.getElementById('sidebarSearch');
   const contentSearch = document.getElementById('contentSearch');
@@ -387,15 +389,18 @@
 
   function setActiveTab(index) {
     activeTabIndex = index;
-    tabs.forEach((tab, i) => {
+    sidebarTabs.forEach((tab, i) => {
       const isActive = i === index;
       tab.classList.toggle('active', isActive);
       tab.setAttribute('tabindex', isActive ? '0' : '-1');
       if (sections[i]) sections[i].hidden = !isActive;
     });
+    bottomTabs.forEach((tab, i) => {
+      tab.classList.toggle('active', i === index);
+    });
     updateSearchFilters();
     // Render profile if it's a profile tab
-    const name = tabs[index].textContent.trim();
+    const name = sidebarTabs[index].textContent.trim();
     if (['Ghassan', 'Mariem', 'Yazid', 'Yahya'].includes(name)) {
       renderSingleProfile(name);
       profileDetailSection.hidden = false;
@@ -405,23 +410,28 @@
   }
   setActiveTab(0);
 
-  tabs.forEach((tab, i) => {
-    tab.addEventListener('click', () => setActiveTab(i));
-    tab.addEventListener('keydown', (e) => {
-      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
-        e.preventDefault();
-        const next = (i + 1) % tabs.length;
-        tabs[next].focus();
-      } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
-        e.preventDefault();
-        const prev = (i - 1 + tabs.length) % tabs.length;
-        tabs[prev].focus();
-      } else if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        setActiveTab(i);
-      }
+  function setupTabListeners(list) {
+    list.forEach((tab, i) => {
+      tab.addEventListener('click', () => setActiveTab(i));
+      tab.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+          e.preventDefault();
+          const next = (i + 1) % tabCount;
+          list[next].focus();
+        } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const prev = (i - 1 + tabCount) % tabCount;
+          list[prev].focus();
+        } else if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setActiveTab(i);
+        }
+      });
     });
-  });
+  }
+
+  setupTabListeners(sidebarTabs);
+  setupTabListeners(bottomTabs);
 
   // ========== Wall Posts ==========
 
@@ -955,7 +965,7 @@
 
   function updateSearchFilters() {
     const filter = contentSearch.value.trim().toLowerCase();
-    const activeTab = tabs[activeTabIndex].textContent.trim();
+    const activeTab = sidebarTabs[activeTabIndex].textContent.trim();
     switch (activeTab) {
       case 'Wall':
         renderWallPosts(filter);
@@ -983,7 +993,7 @@
 
   sidebarSearch.addEventListener('input', () => {
     const query = sidebarSearch.value.trim().toLowerCase();
-    tabs.forEach(li => {
+    sidebarTabs.forEach(li => {
       li.style.display = li.textContent.toLowerCase().includes(query) ? '' : 'none';
     });
   });
@@ -1228,7 +1238,7 @@
     });
   }
   // Close sidebar when a menu item is selected on small screens
-  tabs.forEach(li => {
+  sidebarTabs.forEach(li => {
     li.addEventListener('click', () => {
       if (window.innerWidth <= 700 && sidebarEl) {
         if (!window.matchMedia('(orientation: portrait)').matches) {

--- a/style.css
+++ b/style.css
@@ -873,3 +873,43 @@ button.btn-secondary:hover {
   justify-content: center;
   font-size: 0.8rem;
 }
+
+/* Bottom navigation for small screens */
+nav.bottom-nav {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--color-card);
+  border-top: 1px solid var(--color-border);
+  box-shadow: 0 -2px 8px rgba(0,0,0,0.1);
+  z-index: 997;
+}
+nav.bottom-nav button {
+  flex: 1;
+  padding: 0.6rem 0;
+  background: none;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+nav.bottom-nav button.active {
+  color: var(--color-primary);
+}
+
+@media (max-width: 600px) {
+  nav.sidebar {
+    display: none;
+  }
+  .hamburger-btn {
+    display: none;
+  }
+  nav.bottom-nav {
+    display: flex;
+  }
+  main.content {
+    padding-bottom: 4rem;
+    max-width: 100vw;
+  }
+}


### PR DESCRIPTION
## Summary
- add new bottom navigation bar for mobile
- hide the sidebar on small screens and style the bottom nav
- update JS tab handling to sync with bottom nav

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688afecf06e08325996b7539bcf32303