### PR TITLE
Add reminder endpoint and push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This repository now includes a minimal Node.js backend that stores app data in a
    ```
    The server listens on port `3000` by default.
 
+   To enable email reminders, set the following optional variables:
+   - `SMTP_HOST` and `SMTP_PORT`
+   - `SMTP_USER` and `SMTP_PASS` for authentication
+   - `SMTP_FROM` (defaults to `SMTP_USER`)
+
 ## Update `script.js`
 Edit `script.js` if the server URL differs. Change the `API_BASE` constant near the top of the file to point to your backend (e.g. `http://localhost:3000/api`).
 
@@ -27,5 +32,7 @@ The backend exposes the following routes:
 - `GET/POST /api/calendarEvents`
 - `GET/POST /api/chores`
 - `GET/POST /api/profiles`
+- `GET /api/reminders` to list scheduled reminders
+- `POST /api/reminders` to schedule a new reminder
 
 The client performs `POST` calls with the entire dataset and expects `JSON` responses. If the server cannot be reached, the app transparently falls back to the data stored in `localStorage`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.18.2",
-        "googleapis": "^130.0.0"
+        "googleapis": "^130.0.0",
+        "nodemailer": "^6.10.1"
       }
     },
     "node_modules/accepts": {
@@ -776,6 +777,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "googleapis": "^130.0.0"
+    "googleapis": "^130.0.0",
+    "nodemailer": "^6.10.1"
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -45,3 +45,11 @@ self.addEventListener('fetch', event => {
     fetch(event.request).catch(() => caches.match(event.request))
   );
 });
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'show-notification') {
+    self.registration.showNotification(event.data.title, {
+      body: event.data.body
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- enable optional email transport and reminder checking
- store reminders in Drive-backed data
- expose `/api/reminders` endpoints for scheduling
- show push notifications for upcoming chores and events
- handle push messages in the service worker
- document new configuration and endpoints

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688afecb948c8325a65e91d8f2aed63d