### PR TITLE
Fix sidebar overlay behavior on tab click

### DIFF
--- a/script.js
+++ b/script.js
@@ -1353,13 +1353,8 @@
   sidebarTabs.forEach(li => {
     li.addEventListener('click', () => {
       if (window.innerWidth <= 700 && sidebarEl) {
-        if (!window.matchMedia('(orientation: portrait)').matches) {
-          sidebarEl.classList.remove('open');
-          if (sidebarOverlayEl) sidebarOverlayEl.classList.remove('visible');
-        } else {
-          sidebarEl.classList.add('open');
-          if (sidebarOverlayEl) sidebarOverlayEl.classList.add('visible');
-        }
+        sidebarEl.classList.remove('open');
+        if (sidebarOverlayEl) sidebarOverlayEl.classList.remove('visible');
       }
     });
   });


### PR DESCRIPTION
## Summary
- close the mobile sidebar overlay when selecting a tab

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688b271d9dec8325b2bfa1b414333528