### PR TITLE
Fix Supabase config integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,6 +246,8 @@
 
   <!-- Load Supabase client library before our script so `createClient` is available -->
   <script type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm"></script>
+  <!-- Project configuration containing SUPABASE_URL and SUPABASE_KEY -->
+  <script src="./config.js"></script>
   <!-- Use a relative path for the script to ensure it loads correctly when deployed in a subdirectory -->
   <script src="./script.js" defer></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -68,15 +68,15 @@
   // ========== Constants and Keys ==========
   const currentUserKey = 'familyCurrentUser';
   const themeKey = 'familyTheme';
-// ====== Supabase Setup ======
-const supabaseUrl = window.https://zlhamcofzyozfyzcgcdg.supabase.co;
-const supabaseKey = window.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InpsaGFtY29menlvemZ5emNnY2RnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5NTM0MjIsImV4cCI6MjA2OTUyOTQyMn0.CqMDQgfpbyWTi3RgA_eitd_Qf7aJu0WruETtws6B5Mo;
-if (!supabaseUrl || !supabaseKey) {
-  alert('Supabase configuration missing. Please set SUPABASE_URL and SUPABASE_KEY in config.js');
-}
-const supabase = window.supabase
-  ? window.supabase.createClient(supabaseUrl, supabaseKey)
-  : createClient(supabaseUrl, supabaseKey);
+  // ====== Supabase Setup ======
+  const supabaseUrl = window.SUPABASE_URL;
+  const supabaseKey = window.SUPABASE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    alert('Supabase configuration missing. Please set SUPABASE_URL and SUPABASE_KEY in config.js');
+  }
+  const supabase = window.supabase
+    ? window.supabase.createClient(supabaseUrl, supabaseKey)
+    : createClient(supabaseUrl, supabaseKey);
   // Admin users and a simple PIN to restrict admin actions. In a real app
   // you would implement proper authentication. Kids cannot log in as
   // Ghassan/Mariem without entering this PIN.


### PR DESCRIPTION
## Summary
- fix bad JS syntax when reading Supabase settings
- include `config.js` in the main page

## Testing
- `npm test`
- `tidy -qe index.html`

------
https://chatgpt.com/codex/tasks/task_e_688ba897d32c832599c1884de9f5a329