### PR TITLE
Fix profile loading and provide localStorage fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ FamilyNest now stores all data in [Supabase](https://supabase.com). The front en
 
 Once those values are set, the application will read and write wall posts, calendar events, chores and profile information directly from Supabase tables.
 
+If the configured Supabase project is missing any of the expected tables, the application will now fall back to using browser `localStorage` so that it can still run without errors.
+


### PR DESCRIPTION
## Summary
- add localStorage fallback when Supabase tables are missing
- ensure `renderSingleProfile` works even if data failed to load
- document fallback behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688baa3cd1fc83258e692ba5bc31af66