### PR TITLE
Fix user switching and profile display

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ import { computeProfileSimilarities, renderSingleProfile, setProfileData } from 
 import { updateGreeting, updateAdminVisibility, loadTheme } from './ui.js';
 import { setupTabListeners, setActiveTab } from './navigation.js';
 import { setupProfileEditListeners } from './profileEditListeners.js';
+import { initUserSwitching } from './user.js';
 import { badgeTypes } from './data.js'; // if you use badgeTypes from your data.js
 
 let wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores;
@@ -93,6 +94,9 @@ export async function main() {
 
   // Profile editing
   setupProfileEditListeners();
+
+  // User selection modal
+  initUserSwitching();
 }
 
 // Fire it up!

--- a/navigation.js
+++ b/navigation.js
@@ -1,5 +1,7 @@
 // navigation.js
 
+import { renderSingleProfile } from './profile.js';
+
 const sidebarTabs = Array.from(document.querySelectorAll('nav.sidebar li'));
 const bottomTabs = Array.from(document.querySelectorAll('nav.bottom-nav button'));
 const sections = Array.from(document.querySelectorAll('main.content > section'));
@@ -38,13 +40,13 @@ export function setActiveTab(index) {
     case 'Yazid':
     case 'Yahya':
       document.getElementById('profileDetail').hidden = false;
-      // renderSingleProfile(tabName); // leave this call in main.js
+      renderSingleProfile(tabName);
       break;
   }
   // updateSearchFilters(); // wire up in main if needed
   if (['Ghassan', 'Mariem', 'Yazid', 'Yahya'].includes(tabName)) {
     document.getElementById('profileDetail').hidden = false;
-    // renderSingleProfile(tabName);
+    renderSingleProfile(tabName);
   } else {
     document.getElementById('profileDetail').hidden = true;
   }

--- a/user.js
+++ b/user.js
@@ -1,0 +1,38 @@
+import { updateGreeting, updateAdminVisibility } from './ui.js';
+
+export function initUserSwitching() {
+  const modal = document.getElementById('userSelectModal');
+  const select = document.getElementById('userSelect');
+  const confirmBtn = document.getElementById('confirmUserBtn');
+  const changeUserBtn = document.getElementById('changeUserBtn');
+  const key = 'familyCurrentUser';
+
+  function showModal() {
+    if (!modal) return;
+    modal.classList.remove('modal-hidden');
+    select && select.focus();
+  }
+
+  function hideModal() {
+    if (!modal) return;
+    modal.classList.add('modal-hidden');
+  }
+
+  confirmBtn?.addEventListener('click', () => {
+    const user = select?.value;
+    if (!user) return;
+    localStorage.setItem(key, user);
+    hideModal();
+    updateGreeting();
+    updateAdminVisibility();
+  });
+
+  changeUserBtn?.addEventListener('click', showModal);
+
+  if (!localStorage.getItem(key)) {
+    showModal();
+  } else {
+    updateGreeting();
+    updateAdminVisibility();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `initUserSwitching` to let visitors choose their name
- automatically render profiles when tabs change
- call the new user setup from the main entrypoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c7b70f7a0832599b290157c3123a8