### PR TITLE
Bug fixes for wall posting and scoreboard reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
     <section id="scoreboard" aria-label="Scoreboard Section" hidden>
       <h1>Scoreboard</h1>
       <ul id="scoreboardList" class="scoreboard-list"></ul>
+      <button id="resetScoreboardBtn" class="btn-secondary">Reset Scoreboard</button>
     </section>
 
     <!-- Profile Detail Section -->

--- a/main.js
+++ b/main.js
@@ -1,11 +1,11 @@
 // main.js
 
 import { loadAllData } from './storage.js';
-import { renderWallPosts } from './wall.js';
+import { renderWallPosts, setWallData, setupWallListeners } from './wall.js';
 import { setupQA, renderQA } from './qa.js';
 import { setupCalendar, renderCalendarTable, renderCalendarEventsList } from './calendar.js';
 import { renderChores, setChoresData, setupChoresUI } from './chores.js';
-import { renderScoreboard, setScoreboardData } from './scoreboard.js';
+import { renderScoreboard, setScoreboardData, setupScoreboardListeners } from './scoreboard.js';
 import { computeProfileSimilarities, renderSingleProfile, setProfileData } from './profile.js';
 import { updateGreeting, updateAdminVisibility, loadTheme } from './ui.js';
 import { setupTabListeners, setActiveTab } from './navigation.js';
@@ -40,6 +40,10 @@ function assignData(allData) {
 export async function main() {
   const allData = await loadAllData();
   assignData(allData);
+
+  // Wall data and interactions
+  setWallData({ wallPostsRef: wallPosts, userKey: 'familyCurrentUser' });
+  setupWallListeners();
 
   // Scoreboard & chores data (no globals)
   setScoreboardData({ userPoints, badges, completedChores });
@@ -109,6 +113,7 @@ export async function main() {
   // Chores & scoreboard
   renderChores('', false);
   renderScoreboard();
+  setupScoreboardListeners();
 
   // Profile editing
   setupProfileEditListeners();

--- a/profile.js
+++ b/profile.js
@@ -2,6 +2,7 @@
 
 import { escapeHtml, calculateAge } from './util.js';
 import { saveToSupabase } from './storage.js';
+import { renderScoreboard } from './scoreboard.js';
 
 // These will be set via setProfileData etc.
 let profilesData = {};
@@ -11,6 +12,10 @@ let userPoints = {};
 let completedChores = {};
 export let currentEditingProfile = null;
 export let profileSimilarities = {};
+
+export function setCurrentEditingProfile(name) {
+  currentEditingProfile = name;
+}
 
 // Optionally let main.js call this to inject/replace shared state.
 export function setProfileData(
@@ -35,14 +40,14 @@ function grantBadge(user, badgeId) {
   if (!badges[user].some((b) => b.id === badgeId)) {
     badges[user].push(badge);
     saveToSupabase('badges', badges);
-    // You may want to refresh scoreboard here!
+    renderScoreboard();
   }
 }
 
 function incrementPoints(user, amount = 1) {
   userPoints[user] = (userPoints[user] || 0) + amount;
   saveToSupabase('user_points', userPoints);
-  // You may want to refresh scoreboard here!
+  renderScoreboard();
 }
 
 const adminUsers = ['Ghassan', 'Mariem'];

--- a/profileEditListeners.js
+++ b/profileEditListeners.js
@@ -1,10 +1,10 @@
 // profileEditListeners.js
 
-import { 
-  getProfilesData, 
-  currentEditingProfile, 
-  renderSingleProfile, 
-  computeProfileSimilarities 
+import {
+  getProfilesData,
+  setCurrentEditingProfile,
+  renderSingleProfile,
+  computeProfileSimilarities
 } from './profile.js';
 import { saveToSupabase } from './storage.js';
 
@@ -17,13 +17,14 @@ export function setupProfileEditListeners() {
   
   // Enter edit mode
   editProfileBtn.addEventListener('click', () => {
-    window.currentEditingProfile = profileNameHeading.dataset.name;
-    renderSingleProfile(window.currentEditingProfile);
+    const name = profileNameHeading.dataset.name;
+    setCurrentEditingProfile(name);
+    renderSingleProfile(name);
   });
 
   // Save profile
   saveProfileBtn.addEventListener('click', () => {
-    const name = window.currentEditingProfile;
+    const name = profileNameHeading.dataset.name;
     if (!name) return;
     const profilesData = getProfilesData(); // <-- Use the getter
     const p = profilesData[name];
@@ -40,13 +41,13 @@ export function setupProfileEditListeners() {
 
     saveToSupabase('profiles', profilesData);
     computeProfileSimilarities(name);
-    window.currentEditingProfile = null;
+    setCurrentEditingProfile(null);
     renderSingleProfile(name);
   });
 
   // Cancel edit
   cancelProfileBtn.addEventListener('click', () => {
-    window.currentEditingProfile = null;
+    setCurrentEditingProfile(null);
     renderSingleProfile(profileNameHeading.dataset.name);
   });
 }

--- a/qa.js
+++ b/qa.js
@@ -101,13 +101,16 @@ function setupQAListeners() {
       const index = qaList.findIndex(item => item.id === id);
       if (index === -1) return;
 
-      if (e.target.classList.contains('delete-q-btn')) {
+      const delBtn = e.target.closest('.delete-q-btn');
+      const editBtn = e.target.closest('.edit-q-btn');
+
+      if (delBtn) {
         if (confirm('Delete this question?')) {
           qaList.splice(index, 1);
           saveToSupabase('qa_table', qaList);
           renderQA(contentSearch?.value || '');
         }
-      } else if (e.target.classList.contains('edit-q-btn')) {
+      } else if (editBtn) {
         enterQAEditMode(id);
       }
     });

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,5 +1,7 @@
 // scoreboard.js
 
+import { saveToSupabase } from './storage.js';
+
 let _userPoints = {};
 let _badges = {};
 let _completedChores = {};
@@ -25,4 +27,25 @@ export function renderScoreboard() {
       <span class="scoreboard-badges">${badgeHtml}</span>`;
     scoreboardList.appendChild(li);
   });
+}
+
+export function resetScoreboard() {
+  _userPoints = {};
+  _badges = {};
+  _completedChores = {};
+  saveToSupabase('user_points', _userPoints);
+  saveToSupabase('badges', _badges);
+  saveToSupabase('completed_chores', _completedChores);
+  renderScoreboard();
+}
+
+export function setupScoreboardListeners() {
+  const resetBtn = document.getElementById('resetScoreboardBtn');
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      if (confirm('Reset all scores and badges?')) {
+        resetScoreboard();
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- wire wall module in main.js
- refresh scoreboard when points or badges change and add reset
- allow profile editing by tracking edit state correctly
- fix QA delete/edit clicks
- add scoreboard reset button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc1f8d7648325953187fd2f4b61a1