### PR TITLE
Add floating sidebar toggle for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,10 @@
     </section>
   </main>
 
+  <button id="floatingMenuBtn" class="floating-menu-btn" aria-label="Open menu">
+    <i class="fa-solid fa-bars"></i>
+  </button>
+
   <nav class="bottom-nav" aria-label="Bottom navigation">
     <button>Wall</button>
     <button>Q&amp;A</button>

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import { renderChores, setChoresData, setupChoresUI } from './chores.js';
 import { renderScoreboard, setScoreboardData, setupScoreboardListeners } from './scoreboard.js';
 import { computeProfileSimilarities, renderSingleProfile, setProfileData } from './profile.js';
 import { updateGreeting, updateAdminVisibility, loadTheme } from './ui.js';
-import { setupTabListeners, setActiveTab } from './navigation.js';
+import { setupTabListeners, setActiveTab, setupSidebarToggle } from './navigation.js';
 import { setupProfileEditListeners } from './profileEditListeners.js';
 import { initUserSwitching } from './user.js';
 import { badgeTypes } from './data.js'; // if you use badgeTypes from your data.js
@@ -97,6 +97,7 @@ export async function main() {
   // Tab nav
   setupTabListeners();
   setActiveTab(0);
+  setupSidebarToggle();
 
   // Render content (all null-checked in modules)
   renderWallPosts();

--- a/navigation.js
+++ b/navigation.js
@@ -73,3 +73,24 @@ export function setupTabListeners() {
     });
   });
 }
+
+export function setupSidebarToggle() {
+  const sidebar = document.querySelector('nav.sidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+  const floatBtn = document.getElementById('floatingMenuBtn');
+  const hamburgerBtn = document.getElementById('hamburgerBtn');
+
+  if (!sidebar || !overlay) return;
+
+  function toggle() {
+    const isOpen = sidebar.classList.toggle('open');
+    overlay.classList.toggle('visible', isOpen);
+    if (floatBtn) floatBtn.setAttribute('aria-expanded', isOpen);
+    if (hamburgerBtn) hamburgerBtn.setAttribute('aria-expanded', isOpen);
+  }
+
+  [floatBtn, hamburgerBtn].forEach(btn => {
+    if (btn) btn.addEventListener('click', toggle);
+  });
+  overlay.addEventListener('click', toggle);
+}

--- a/style.css
+++ b/style.css
@@ -812,6 +812,25 @@ button.btn-secondary:hover {
   color: var(--color-primary);
 }
 
+/* Floating menu button for small screens */
+.floating-menu-btn {
+  position: fixed;
+  bottom: 4.5rem;
+  right: 1rem;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  z-index: 1000;
+}
+
 /* Overlay behind the sidebar when open on small screens */
 .sidebar-overlay {
   position: fixed;
@@ -942,11 +961,11 @@ nav.bottom-nav button.active {
 }
 
 @media (max-width: 600px) {
-  nav.sidebar {
-    display: none;
-  }
   .hamburger-btn {
     display: none;
+  }
+  .floating-menu-btn {
+    display: flex;
   }
   nav.bottom-nav {
     display: flex;


### PR DESCRIPTION
## Summary
- add floating sidebar menu button in HTML
- style floating menu button and show on small screens
- expose sidebar toggle behaviour in navigation.js
- initialize sidebar toggle from main.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc732039c8325851821d6ba632111