### PR TITLE
Fix wall post ordering and deletion persistence

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -83,6 +83,23 @@ export async function saveToSupabase(table, data) {
   }
 }
 
+export async function deleteFromSupabase(table, id) {
+  table = resolveTable(table);
+  if (!supabaseEnabled) {
+    const current = loadFromLocal(table, []);
+    if (Array.isArray(current)) {
+      const filtered = current.filter(item => item.id !== id);
+      saveToLocal(table, filtered);
+    }
+    return;
+  }
+  const { error } = await supabase.from(table).delete().eq('id', id);
+  if (error) {
+    console.error('Supabase delete error:', error);
+    showAlert('Could not delete data.');
+  }
+}
+
 export function loadFromLocal(table, defaultValue) {
   table = resolveTable(table);
   try {

--- a/wall.js
+++ b/wall.js
@@ -1,6 +1,6 @@
 // wall.js
 
-import { saveToSupabase } from './storage.js';
+import { saveToSupabase, deleteFromSupabase } from './storage.js';
 import { escapeHtml, formatDateLocal, timeAgo, generateId, showAlert } from './util.js';
 
 // These should be injected by main.js/init, but we always lookup live DOM
@@ -32,7 +32,9 @@ export function renderWallPosts(filterText = '') {
   if (!wallPostsList) return; // DOM not ready yet!
   wallPostsList.innerHTML = '';
 
-  const posts = Array.isArray(wallPosts) ? wallPosts : [];
+  const posts = Array.isArray(wallPosts)
+    ? [...wallPosts].sort((a, b) => new Date(b.date) - new Date(a.date))
+    : [];
   let filteredPosts = posts;
   if (filterText) {
     const f = filterText.toLowerCase();
@@ -99,6 +101,7 @@ export function setupWallListeners() {
       } else if (btn.classList.contains('delete-btn')) {
         if (confirm('Delete this post?')) {
           wallPosts.splice(postIndex, 1);
+          deleteFromSupabase('wall_posts', postId);
           saveToSupabase('wall_posts', wallPosts);
           renderWallPosts(contentSearch ? contentSearch.value : '');
         }


### PR DESCRIPTION
## Summary
- keep wall posts sorted by most recent date
- add Supabase helper for deleting rows
- remove deleted posts from Supabase when removed from UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc88295988325aa2d006f391f2c50