### PR TITLE
Fix 404 errors loading Supabase and favicon

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,5 @@
 import { main } from "./main.js";
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/supabase.min.js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 const supabaseUrl = window.SUPABASE_URL;
 const supabaseKey = window.SUPABASE_KEY;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="manifest" href="./manifest.json">
   <!-- Set a base URL so that all relative resources (CSS/JS/icons) are resolved relative to the app root, not the domain root. -->
   <base href="./">
+  <link rel="icon" href="./icons/favicon.ico">
   <link rel="stylesheet" href="./style.css" >
   <!-- Supabase SDK, must load before app code -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>


### PR DESCRIPTION
## Summary
- correct Supabase CDN path
- add favicon link in HTML head

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d0ddf76c083258f781d135660fccb