### PR TITLE
Add poll support to wall posts

### DIFF
--- a/data.js
+++ b/data.js
@@ -54,6 +54,24 @@ export const defaultWallPosts = [
     edited: false,
     userReactions: {},
     replies: []
+  },
+  {
+    id: generateId(),
+    member: "Mariem",
+    text: "What's your favorite family activity?",
+    date: "2025-07-28T18:00:00",
+    reactions: {},
+    edited: false,
+    userReactions: {},
+    replies: [],
+    poll: {
+      multiple: false,
+      options: [
+        { id: generateId(), text: "Game night", votes: [] },
+        { id: generateId(), text: "Movie time", votes: [] },
+        { id: generateId(), text: "Outdoor adventure", votes: [] }
+      ]
+    }
   }
 ];
 

--- a/index.html
+++ b/index.html
@@ -73,7 +73,19 @@
     <!-- Wall Section -->
     <section id="wall" aria-label="Wall Section">
       <h1>Wall</h1>
-      <textarea id="newWallPost" placeholder="Write something..." rows="3" aria-label="New wall post" ></textarea>
+      <select id="postTypeSelect" aria-label="Select post type">
+        <option value="text">Post</option>
+        <option value="poll">Poll</option>
+      </select>
+      <textarea id="newWallPost" placeholder="Write something..." rows="3" aria-label="New wall post"></textarea>
+      <div id="pollFields" class="poll-fields" hidden>
+        <div id="pollOptions" class="poll-options-edit">
+          <input type="text" class="poll-option-input" placeholder="Option 1">
+          <input type="text" class="poll-option-input" placeholder="Option 2">
+        </div>
+        <button type="button" id="addPollOptionBtn">Add Option</button>
+        <label class="poll-multiple-label"><input type="checkbox" id="pollMultiple"> Allow multiple selections</label>
+      </div>
       <br>
       <button class="add-btn" id="addWallPostBtn">Post</button>
       <ul class="wall-posts" aria-live="polite" aria-atomic="true" aria-relevant="additions" id="wallPostsList"></ul>

--- a/style.css
+++ b/style.css
@@ -380,6 +380,62 @@ ul.wall-posts li strong {
   font-size: 1rem;
 }
 
+/* ==== Poll creation fields ==== */
+.poll-fields {
+  margin-top: 0.5rem;
+}
+.poll-fields input {
+  display: block;
+  margin: 0.25rem 0;
+  border-radius: 8px;
+  padding: 0.4rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+}
+.poll-fields button {
+  margin-top: 0.25rem;
+}
+
+/* ==== Poll display ==== */
+.poll-question {
+  margin-top: 0.3rem;
+  font-weight: 600;
+}
+.poll-options {
+  list-style: none;
+  padding: 0;
+  margin-top: 0.5rem;
+}
+.poll-options li {
+  margin-bottom: 0.3rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.poll-options button {
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.poll-bar {
+  flex-grow: 1;
+  height: 8px;
+  background: var(--color-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.poll-bar-fill {
+  background: var(--accent-color);
+  height: 100%;
+  display: block;
+}
+.poll-count {
+  font-size: 0.8rem;
+}
+
 ul.qa-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- enable selecting post type for the Wall
- add poll creation fields and related styles
- render polls and handle voting
- store poll votes per user and include a default poll example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d3dd0833883259c1095765b0e1517