### PR TITLE
Fix service worker cache paths and supabase error fallback

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -98,6 +98,12 @@ export async function saveToSupabase(table, data, opts = {}) {
       if (!skipLocal) saveToLocal(table, data);
       return;
     }
+    if (error.code === '23502') {
+      console.info(`Supabase schema mismatch for '${table}' - using localStorage.`);
+      supabaseEnabled = false;
+      if (!skipLocal) saveToLocal(table, data);
+      return;
+    }
     console.error('Supabase save error:', error);
     showAlert('Could not save data. Changes stored locally.');
     if (!skipLocal) saveToLocal(table, data);

--- a/sw.js
+++ b/sw.js
@@ -2,13 +2,13 @@
 
 const CACHE_NAME = 'family-hub-v1';
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/main.js', // Change to your actual entry file
-  '/styles.css',
-  '/icons/default-avatar.svg',
-  '/icons/icon-192.png',
-  '/icons/icon-512.png',
+  './',
+  './index.html',
+  './main.js',
+  './style.css',
+  './icons/default-avatar.svg',
+  './icons/icon-192.png',
+  './icons/icon-512.png',
   // Add more static assets if needed
 ];
 


### PR DESCRIPTION
## Summary
- cache correct file names in `sw.js`
- fall back to localStorage when Supabase returns a schema violation error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d465fdbb48325b0873cfdec0fd095