### PR TITLE
Fix service worker cache error due to incorrect icon paths

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -7,8 +7,8 @@ const URLS_TO_CACHE = [
   './main.js',
   './style.css',
   './icons/default-avatar.svg',
-  './icons/icon-192.png',
-  './icons/icon-512.png',
+  './icons/house-192.png',
+  './icons/house-512.png',
   // Add more static assets if needed
 ];
 


### PR DESCRIPTION
## Summary
- Correct service worker cache list to use existing icon file names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7ab46db483259ee684fe6981f4ff