### PR TITLE
Restrict point adjustments to admins and log changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ FamilyNest expects the following tables to exist in your Supabase project:
 | `chores`         | Chores assigned to family members  | `id` (text), `desc` (text), `assignedTo` (text), `due` (date), `daily` (boolean), `completed` (boolean) |
 | `reminders`      | Reminders for family members       | `id` (text), `text` (text), `date` (timestamp) |
 | `user_points`    | Points for each family member       | `name` (text), `value` (integer)      |
+| `point_logs`     | Log of point changes                | `id` (text), `user` (text), `admin` (text), `amount` (integer), `timestamp` (timestamp) |
 | `badges`         | Earned badges for members           | `name` (text), `value` (json)         |
 | `completed_chores`| Total chores completed            | `name` (text), `value` (integer)      |
 

--- a/data.js
+++ b/data.js
@@ -158,3 +158,4 @@ export const defaultChores = [
 export const defaultUserPoints = { Ghassan: 0, Mariem: 0, Yazid: 0, Yahya: 0 };
 export const defaultBadges = { Ghassan: [], Mariem: [], Yazid: [], Yahya: [] };
 export const defaultCompletedChores = { Ghassan: 0, Mariem: 0, Yazid: 0, Yahya: 0 };
+export const defaultPointLogs = [];

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ import { setupProfileEditListeners } from './profileEditListeners.js';
 import { badgeTypes } from './data.js'; // if you use badgeTypes from your data.js
 import { initNotifications, clearTabDot } from './notifications.js';
 
-let wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores;
+let wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores, pointLogs;
 
 // Assign loaded state to locals, also inject into window if you want
 function assignData(allData) {
@@ -25,6 +25,7 @@ function assignData(allData) {
   userPoints = allData.userPoints;
   badges = allData.badges;
   completedChores = allData.completedChores;
+  pointLogs = allData.pointLogs;
 
   // If you want dev/legacy access
   window.wallPosts = wallPosts;
@@ -35,6 +36,7 @@ function assignData(allData) {
   window.userPoints = userPoints;
   window.badges = badges;
   window.completedChores = completedChores;
+  window.pointLogs = pointLogs;
 }
 
 export async function main() {
@@ -61,7 +63,7 @@ export async function main() {
       saveToSupabase('user_points', userPoints);
     }
   });
-  setProfileData(profilesData, badges, badgeTypes, userPoints, completedChores);
+  setProfileData(profilesData, badges, badgeTypes, userPoints, completedChores, pointLogs);
 
   // Q&A robust setup (NO undefined errors!)
   setupQA({

--- a/profile.js
+++ b/profile.js
@@ -10,6 +10,7 @@ let badgeTypes = [];
 let badges = {};
 let userPoints = {};
 let completedChores = {};
+let pointLogs = [];
 export let currentEditingProfile = null;
 export let profileSimilarities = {};
 
@@ -23,13 +24,15 @@ export function setProfileData(
   badgeData = {},
   badgeTypeData = [],
   userPts = {},
-  completed = {}
+  completed = {},
+  pointLogsData = []
 ) {
   profilesData = data;
   badges = badgeData;
   badgeTypes = badgeTypeData;
   userPoints = userPts;
   completedChores = completed;
+  pointLogs = pointLogsData;
 }
 
 // Grant badge and increment points should ideally be imported, but can be local here for now:
@@ -58,8 +61,18 @@ function revokeBadge(user, badgeId) {
 }
 
 function incrementPoints(user, amount = 1) {
+  const admin = localStorage.getItem('familyCurrentUser');
+  if (!adminUsers.includes(admin)) return;
   userPoints[user] = (userPoints[user] || 0) + amount;
   saveToSupabase('user_points', userPoints);
+  pointLogs.push({
+    id: generateId(),
+    user,
+    admin,
+    amount,
+    timestamp: new Date().toISOString()
+  });
+  saveToSupabase('point_logs', pointLogs);
   renderScoreboard();
 }
 
@@ -300,7 +313,15 @@ export function renderSingleProfile(name) {
       incrementPoints(name);
       renderSingleProfile(name);
     });
+    const subBtn = document.createElement('button');
+    subBtn.className = 'btn-secondary';
+    subBtn.textContent = '-1 Point';
+    subBtn.addEventListener('click', () => {
+      incrementPoints(name, -1);
+      renderSingleProfile(name);
+    });
     pointsDiv.appendChild(addBtn);
+    pointsDiv.appendChild(subBtn);
   }
   profileContainer.appendChild(pointsDiv);
 

--- a/storage.js
+++ b/storage.js
@@ -9,7 +9,8 @@ import {
   defaultChores,
   defaultUserPoints,
   defaultBadges,
-  defaultCompletedChores
+  defaultCompletedChores,
+  defaultPointLogs
 } from './data.js';
 
 import { generateId, showAlert } from './util.js';
@@ -225,5 +226,6 @@ export async function loadAllData() {
   let userPoints = await loadFromSupabase('user_points', defaultUserPoints);
   let badges = await loadFromSupabase('badges', defaultBadges);
   let completedChores = await loadFromSupabase('completed_chores', defaultCompletedChores);
-  return { wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores };
+  let pointLogs = await loadFromSupabase('point_logs', defaultPointLogs);
+  return { wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores, pointLogs };
 }


### PR DESCRIPTION
## Summary
- Track point modifications in new `point_logs` dataset for audit trail
- Only admins can adjust points through new +1/-1 controls
- Persist point change logs with admin user and timestamp

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688da8c255608325a60defd88773227f