### PR TITLE
Add admin settings menu with scoreboard reset and photo cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
           </button>
           <div id="profileMenu" class="profile-menu" hidden>
             <button id="profileMenuProfile">Profile</button>
+            <button id="profileMenuSettings" class="admin-only">Settings</button>
             <hr>
             <button id="signOutBtn" class="sign-out">Sign Out</button>
           </div>
@@ -214,6 +215,13 @@
     <section id="settings" aria-label="Settings Section" hidden>
       <h1>Settings</h1>
       <button id="resetScoreboardBtn" class="btn-secondary">Reset Scoreboard</button>
+      <div id="photoCleanup" class="admin-only">
+        <h2>Photo Cleanup</h2>
+        <button id="cleanupPhotosWeekBtn" class="btn-secondary">Remove photos older than 1 week</button>
+        <button id="cleanupPhotosMonthBtn" class="btn-secondary">Remove photos older than 1 month</button>
+        <button id="cleanupPhotosAllBtn" class="btn-secondary">Remove all photos</button>
+        <div id="photoCleanupStatus" aria-live="polite"></div>
+      </div>
     </section>
 
     <!-- Profile Detail Section -->

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ import { setupProfileEditListeners } from './profileEditListeners.js';
 import { badgeTypes } from './data.js'; // if you use badgeTypes from your data.js
 import { initNotifications, clearTabDot } from './notifications.js';
 import { setPointLogsData, renderPointLogs, setupPointLogFilters } from './pointLogs.js';
+import { setupSettings } from './settings.js';
 
 let wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores, pointLogs;
 
@@ -128,6 +129,7 @@ export async function main() {
   setupScoreboardListeners();
   renderPointLogs();
   setupPointLogFilters();
+  setupSettings();
 
   // Profile editing
   setupProfileEditListeners();

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,6 +1,6 @@
 // scoreboard.js
 
-import { saveToSupabase } from './storage.js';
+import { saveToSupabase, logAdminAction } from './storage.js';
 import { adminUsers } from './data.js';
 
 let _userPoints = {};
@@ -61,23 +61,26 @@ export function renderScoreboard() {
   });
 }
 
-export function resetScoreboard() {
+export async function resetScoreboard() {
   const user = localStorage.getItem('familyCurrentUser');
   if (!adminUsers.includes(user)) return;
   _userPoints = {};
   _badges = {};
   _completedChores = {};
-  saveToSupabase('user_points', _userPoints);
-  saveToSupabase('badges', _badges);
-  saveToSupabase('completed_chores', _completedChores);
+  await saveToSupabase('user_points', _userPoints);
+  await saveToSupabase('badges', _badges);
+  await saveToSupabase('completed_chores', _completedChores);
   renderScoreboard();
+  await logAdminAction('reset scoreboard');
 }
 
 export function setupScoreboardListeners() {
   const resetBtn = document.getElementById('resetScoreboardBtn');
   if (resetBtn) {
     resetBtn.addEventListener('click', () => {
-      resetScoreboard();
+      if (confirm('Are you sure you want to reset the scoreboard?')) {
+        resetScoreboard();
+      }
     });
   }
 

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,26 @@
+import { cleanupPhotos } from './wall.js';
+import { adminUsers } from './data.js';
+
+export function setupSettings() {
+  const currentUser = localStorage.getItem('familyCurrentUser');
+  if (!adminUsers.includes(currentUser)) return;
+
+  const weekBtn = document.getElementById('cleanupPhotosWeekBtn');
+  const monthBtn = document.getElementById('cleanupPhotosMonthBtn');
+  const allBtn = document.getElementById('cleanupPhotosAllBtn');
+  const status = document.getElementById('photoCleanupStatus');
+
+  async function handle(days) {
+    let label = 'all photos';
+    if (days === 7) label = 'photos older than 1 week';
+    else if (days === 30) label = 'photos older than 1 month';
+    if (!confirm(`Are you sure you want to remove ${label}?`)) return;
+    if (status) status.textContent = 'Cleaning...';
+    const removed = await cleanupPhotos(days);
+    if (status) status.textContent = `Removed ${removed} photo${removed === 1 ? '' : 's'}.`;
+  }
+
+  if (weekBtn) weekBtn.addEventListener('click', () => handle(7));
+  if (monthBtn) monthBtn.addEventListener('click', () => handle(30));
+  if (allBtn) allBtn.addEventListener('click', () => handle(0));
+}

--- a/storage.js
+++ b/storage.js
@@ -26,7 +26,7 @@ const supabaseUrl = window.SUPABASE_URL || '';
 const supabaseKey = window.SUPABASE_KEY || '';
 
 let supabaseEnabled = true;
-let supabase;
+export let supabase;
 
 if (!supabaseUrl || !supabaseKey) {
   alert('Supabase configuration missing. Please set SUPABASE_URL and SUPABASE_KEY in config.js');
@@ -228,4 +228,14 @@ export async function loadAllData() {
   let completedChores = await loadFromSupabase('completed_chores', defaultCompletedChores);
   let pointLogs = await loadFromSupabase('point_logs', defaultPointLogs);
   return { wallPosts, qaList, calendarEvents, profilesData, chores, userPoints, badges, completedChores, pointLogs };
+}
+
+// Log admin actions with timestamp
+export async function logAdminAction(action) {
+  const admin = localStorage.getItem('familyCurrentUser') || 'unknown';
+  const entry = { id: generateId(), admin_id: admin, action, timestamp: new Date().toISOString() };
+  const logs = loadFromLocal('admin_logs', []);
+  logs.push(entry);
+  saveToLocal('admin_logs', logs);
+  await saveToSupabase('admin_logs', entry, { skipLocal: true });
 }

--- a/ui.js
+++ b/ui.js
@@ -70,12 +70,23 @@ if (profileMenuBtn && profileMenu) {
   });
 
   const profileBtn = document.getElementById('profileMenuProfile');
+  const settingsBtn = document.getElementById('profileMenuSettings');
   const signOutBtn = document.getElementById('signOutBtn');
   if (profileBtn) {
     profileBtn.addEventListener('click', () => {
       const user = localStorage.getItem(currentUserKey);
       const tabs = Array.from(document.querySelectorAll('nav.sidebar li'));
       const idx = tabs.findIndex(t => t.textContent.trim() === user);
+      if (idx >= 0) {
+        import('./navigation.js').then(m => m.setActiveTab(idx));
+      }
+      profileMenu.hidden = true;
+    });
+  }
+  if (settingsBtn) {
+    settingsBtn.addEventListener('click', () => {
+      const tabs = Array.from(document.querySelectorAll('nav.sidebar li'));
+      const idx = tabs.findIndex(t => t.textContent.trim() === 'Settings');
       if (idx >= 0) {
         import('./navigation.js').then(m => m.setActiveTab(idx));
       }


### PR DESCRIPTION
## Summary
- Add Settings option to admin avatar dropdown
- Move reset scoreboard to settings with confirmation and logging
- Implement photo cleanup controls for removing old or all uploaded photos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db12bdb1083258c683bbeccedc2b7