### PR TITLE
Improve post card layout on wall

### DIFF
--- a/style.css
+++ b/style.css
@@ -362,10 +362,17 @@ h3 { font-size: 1.5rem; }
   padding: 0.5rem 1.5rem;
   margin-top: 0 !important;
 }
-.wall-photo-preview,
-.wall-post-image {
+.wall-photo-preview {
   max-width: 150px;
   max-height: 150px;
+  margin-top: 0.5rem;
+  border-radius: 8px;
+  display: block;
+}
+
+.wall-post-image {
+  max-width: 100%;
+  height: auto;
   margin-top: 0.5rem;
   border-radius: 8px;
   display: block;
@@ -385,19 +392,33 @@ ul.wall-posts li {
   border-radius: 15px;
   border: 1px solid var(--color-border);
   padding: 1rem 1.5rem;
-  margin-bottom: 1rem;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.06);
   position: relative;
   word-wrap: break-word;
 }
-ul.wall-posts li strong {
+.wall-post-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.avatar-post {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.wall-post-user {
   color: var(--accent-color);
+  font-weight: 700;
+  font-size: 1.1rem;
   user-select: text;
 }
 .wall-post-date {
   font-size: 0.8rem;
   color: #555;
-  margin-left: 6px;
+  margin-left: 4px;
   font-weight: 400;
   user-select: none;
 }
@@ -409,16 +430,34 @@ ul.wall-posts li strong {
 .wall-post-actions {
   margin-top: 8px;
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.reaction-group,
+.action-group {
+  display: flex;
   gap: 10px;
+  align-items: center;
 }
 .wall-post-actions button {
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1.1rem;
+  font-size: 1rem;
   user-select: none;
   transition: transform 0.15s ease;
   padding: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.reaction-btn {
+  font-size: 1.1rem;
+}
+.reaction-btn.active {
+  background: var(--color-accent);
+  border-radius: 8px;
 }
 .wall-post-actions button i {
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Increase spacing and add card styling for wall posts
- Add avatars, relative timestamps, and reaction tooltips
- Group post actions with icons and respect authorship permissions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688db471dd408325ab80c285cc1b551f