### PR TITLE
Handle Supabase schema mismatch for wall post photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ FamilyNest expects the following tables to exist in your Supabase project:
 
 | Table            | Description                        | Example Columns                       |
 |------------------|------------------------------------|---------------------------------------|
-| `wall_posts`     | Posts on the family wall           | `id` (text), `member` (text), `text` (text), `date` (timestamp), `reactions` (json) |
+| `wall_posts`     | Posts on the family wall           | `id` (text), `member` (text), `text` (text), `date` (timestamp), `reactions` (json), `edited` (boolean), `userReactions` (json), `replies` (json), `photo` (text) |
 | `qa_table`       | Questions and answers              | `id` (text), `q` (text), `a` (text)   |
 | `calendar_events`| Events for the family calendar     | `id` (text), `start` (date), `end` (date), `desc` (text) |
 | `profiles`       | Profile information for each user  | `name` (text), `value` (json)         |

--- a/storage.js
+++ b/storage.js
@@ -99,7 +99,7 @@ export async function saveToSupabase(table, data, opts = {}) {
       if (!skipLocal) saveToLocal(table, data);
       return;
     }
-    if (error.code === '23502') {
+    if (error.code === '23502' || error.code === '42703') {
       console.info(`Supabase schema mismatch for '${table}' - using localStorage.`);
       supabaseEnabled = false;
       if (!skipLocal) saveToLocal(table, data);


### PR DESCRIPTION
## Summary
- Guard Supabase writes against missing columns such as the new `photo` field on wall posts
- Document required `photo` column for `wall_posts` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db7e5fa3083259c167490fd35be91