### PR TITLE
style: add small avatar classes for wall posts and replies

### DIFF
--- a/style.css
+++ b/style.css
@@ -400,13 +400,14 @@ ul.wall-posts li {
 .wall-post-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
 }
-.avatar-post {
-  width: 36px;
-  height: 36px;
+.wall-post-avatar,
+.reply-avatar {
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   object-fit: cover;
+  margin-right: 8px;
   flex-shrink: 0;
 }
 .wall-post-user {
@@ -467,7 +468,7 @@ ul.wall-posts li {
 }
 .reply-list {
   list-style: none;
-  padding-left: 1rem;
+  padding-left: 0.5rem;
   margin-top: 0.5rem;
   border-left: 2px solid var(--color-border);
 }

--- a/wall.js
+++ b/wall.js
@@ -102,7 +102,7 @@ export function renderWallPosts(filterText = '') {
       return `
       <li data-id="${r.id}">
         <div class="wall-post-header">
-          <img src="${rAvatar}" alt="${escapeHtml(r.member)} avatar" class="avatar-post">
+          <img src="${rAvatar}" alt="${escapeHtml(r.member)} avatar" class="reply-avatar">
           <strong class="wall-post-user">${escapeHtml(r.member)}</strong>
           <span class="wall-post-date" title="${formatDateLocal(r.date)}">${timeAgo(r.date)}</span>
         </div>
@@ -139,7 +139,7 @@ export function renderWallPosts(filterText = '') {
     const avatar = (window.profilesData && window.profilesData[post.member] && window.profilesData[post.member].avatar) || 'icons/default-avatar.svg';
     const headerHtml = `
       <div class="wall-post-header">
-        <img src="${avatar}" alt="${escapeHtml(post.member)} avatar" class="avatar-post">
+        <img src="${avatar}" alt="${escapeHtml(post.member)} avatar" class="wall-post-avatar">
         <strong class="wall-post-user">${escapeHtml(post.member)}</strong>
         <span class="wall-post-date" title="${formatDateLocal(post.date)}">${timeAgo(post.date)}${post.edited ? ' (edited)' : ''}</span>
       </div>`;
@@ -479,7 +479,7 @@ function enterWallPostEditMode(postId, filterText) {
   const avatar = (window.profilesData && window.profilesData[post.member] && window.profilesData[post.member].avatar) || 'icons/default-avatar.svg';
   li.innerHTML = `
     <div class="wall-post-header">
-      <img src="${avatar}" alt="${escapeHtml(post.member)} avatar" class="avatar-post">
+      <img src="${avatar}" alt="${escapeHtml(post.member)} avatar" class="wall-post-avatar">
       <strong class="wall-post-user">${escapeHtml(post.member)}</strong>
       <span class="wall-post-date" title="${formatDateLocal(post.date)}">Editing</span>
     </div>


### PR DESCRIPTION
## Summary
- define `.wall-post-avatar` and `.reply-avatar` CSS classes for compact circular avatars
- apply new avatar classes in wall posts and replies and trim reply list indentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688db97fa2788325bd400f81fbbea353