### PR TITLE
Ensure wall post images are constrained in size

### DIFF
--- a/style.css
+++ b/style.css
@@ -372,7 +372,10 @@ h3 { font-size: 1.5rem; }
 
 .wall-post-image {
   max-width: 100%;
+  width: 100%;
   height: auto;
+  max-height: 300px;
+  object-fit: cover;
   margin-top: 0.5rem;
   border-radius: 8px;
   display: block;


### PR DESCRIPTION
## Summary
- Limit wall post images to a 300px height and let them scale down to container width
- Use `object-fit: cover` to keep images proportionate while filling their box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dbbdcdad883258090875dc7a72b53