### PR TITLE
Enable chore editing for admins and fix scoreboard reset alert duplication

### DIFF
--- a/chores.js
+++ b/chores.js
@@ -90,8 +90,15 @@ export function renderChores(filterText = '', dailyOnly = false) {
       li.appendChild(dueSpan);
     }
 
-    // Admin delete button (if you want)
-    if (window.localStorage.getItem('familyCurrentUser') === 'Ghassan' /*or admin logic*/) {
+    // Admin-only controls
+    if (isAdmin) {
+      const editBtn = document.createElement('button');
+      editBtn.textContent = '✏️';
+      editBtn.title = 'Edit chore';
+      editBtn.className = 'chore-edit-btn';
+      editBtn.onclick = () => editChore(item.id);
+      li.appendChild(editBtn);
+
       const delBtn = document.createElement('button');
       delBtn.textContent = '🗑️';
       delBtn.title = 'Delete chore';
@@ -171,6 +178,26 @@ export function deleteChore(id) {
     _onSave(_chores, _completedChores, _badges, _userPoints);
     renderChores();
   }
+}
+
+export function editChore(id) {
+  const chore = _chores.find(ch => ch.id === id);
+  if (!chore) return;
+  const newDesc = prompt('Edit description', chore.desc);
+  if (newDesc === null) return;
+  const newAssignee = prompt('Assign to', chore.assignedTo);
+  if (newAssignee === null) return;
+  let newDue = chore.due;
+  if (!chore.daily) {
+    const duePrompt = prompt('Due date', chore.due || '');
+    if (duePrompt === null) return;
+    newDue = duePrompt;
+  }
+  chore.desc = newDesc.trim() || chore.desc;
+  chore.assignedTo = newAssignee.trim() || chore.assignedTo;
+  if (!chore.daily) chore.due = newDue.trim();
+  _onSave(_chores, _completedChores, _badges, _userPoints);
+  renderChores();
 }
 
 export function setupChoresUI({

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -8,6 +8,7 @@ let _userPoints = {};
 let _badges = {};
 let _completedChores = {};
 let _sortBy = 'points';
+let listenersInitialized = false;
 
 export function setScoreboardData({ userPoints, badges, completedChores }) {
   _userPoints = userPoints;
@@ -89,6 +90,9 @@ export async function resetScoreboard() {
 }
 
 export function setupScoreboardListeners() {
+  if (listenersInitialized) return;
+  listenersInitialized = true;
+
   const resetBtn = document.getElementById('resetScoreboardBtn');
   if (resetBtn) {
     resetBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Allow administrators to edit chores directly from the chore list
- Prevent multiple scoreboard reset confirmations by guarding event listeners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dbc90e7548325a82e172a841574f1