### PR TITLE
fix: scale wall post images responsively

### DIFF
--- a/style.css
+++ b/style.css
@@ -370,12 +370,17 @@ h3 { font-size: 1.5rem; }
   display: block;
 }
 
-.wall-post-image {
-  max-width: 100%;
+.wall-post {
   width: 100%;
+  max-width: 100%;
+}
+
+.wall-post-image {
+  width: 100%;
+  max-width: 100%;
   height: auto;
   max-height: 300px;
-  object-fit: cover;
+  object-fit: contain;
   margin-top: 0.5rem;
   border-radius: 8px;
   display: block;

--- a/wall.js
+++ b/wall.js
@@ -92,6 +92,7 @@ export function renderWallPosts(filterText = '') {
   const currentUser = localStorage.getItem(currentUserKey);
   filteredPosts.forEach(post => {
     const li = document.createElement('li');
+    li.classList.add('wall-post');
     li.setAttribute('data-id', post.id);
     li.setAttribute('tabindex', '0');
     const safeText = escapeHtml(post.text);


### PR DESCRIPTION
## Summary
- add `wall-post` class to list items so post images can be targeted
- constrain wall post images to container width and 300px tall with object-fit containment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e2026839883259b20f41c583a2169