### PR TITLE
Fix undefined post variable in wall click handler

### DIFF
--- a/wall.js
+++ b/wall.js
@@ -293,6 +293,7 @@ export function setupWallListeners() {
       const postId = li.getAttribute('data-id');
       const postIndex = wallPosts.findIndex(p => p.id === postId);
       if (postIndex === -1) return;
+      const post = wallPosts[postIndex];
 
       const btn = e.target.closest('button');
       if (!btn) return;


### PR DESCRIPTION
## Summary
- Define `post` from `wallPosts` before handling wall post actions so edit/delete restrictions work without throwing a ReferenceError

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e234042ec8325a69c38b9917961e3