### PR TITLE
feat: paginate wall posts and highlight mentions

### DIFF
--- a/style.css
+++ b/style.css
@@ -437,6 +437,14 @@ ul.wall-posts li {
   user-select: text;
   white-space: pre-wrap;
 }
+.wall-post-text .mention {
+  color: var(--accent-color);
+  font-weight: 600;
+}
+.wall-post-text .hashtag {
+  color: var(--color-secondary);
+  font-weight: 600;
+}
 .wall-post-actions {
   margin-top: 8px;
   display: flex;


### PR DESCRIPTION
## Summary
- add simple pagination with infinite scroll for wall posts
- detect and style @mentions and #hashtags in posts and replies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e241cf70c8325aef874d8907204ea