### PR TITLE
feat: auto-scale wall images

### DIFF
--- a/style.css
+++ b/style.css
@@ -375,15 +375,21 @@ h3 { font-size: 1.5rem; }
   max-width: 100%;
 }
 
-.wall-post > img {
+.wall-post-image {
+  display: block;
   max-width: 100%;
-  width: 100%;
+  width: auto;
   height: auto;
-  max-height: 300px;
-  object-fit: cover;
+  max-height: 60vh;
+  object-fit: contain;
   margin-top: 0.5rem;
   border-radius: 8px;
-  display: block;
+}
+
+@media (max-width: 600px) {
+  .wall-post-image {
+    max-height: 40vh;
+  }
 }
 
 ul.wall-posts {


### PR DESCRIPTION
## Summary
- resize uploaded images to under 2MB using canvas
- remove 2MB alert and preview scaled image automatically
- make wall post images responsive on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e25874ff08325b51803ee0bcc8cb1