### PR TITLE
Prevent duplicate scoreboard reset alerts and unify notifications

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,6 @@
 import { main } from "./main.js";
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
+import { showAlert } from './util.js';
 
 const supabaseUrl = window.SUPABASE_URL;
 const supabaseKey = window.SUPABASE_KEY;
@@ -39,7 +40,7 @@ export function initAuth(onSignedIn) {
       if (typeof onSignedIn === 'function') onSignedIn();
     } else {
       if (user && !allowed[user.email]) {
-        alert('This email is not allowed.');
+        showAlert('This email is not allowed.');
         await supabase.auth.signOut();
       }
       localStorage.removeItem('familyCurrentUser');

--- a/calendar.js
+++ b/calendar.js
@@ -173,7 +173,7 @@ function calendarTableClickHandler(e) {
   const filtered = calendarEvents.filter(ev => ev.start <= date && ev.end >= date);
   if (filtered.length) {
     const msg = filtered.map(ev => `${ev.desc} (${ev.start}${ev.end && ev.end !== ev.start ? '–' + ev.end : ''})`).join('\n');
-    alert(msg);
+    showAlert(msg);
   }
 }
 

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -8,7 +8,6 @@ let _userPoints = {};
 let _badges = {};
 let _completedChores = {};
 let _sortBy = 'points';
-let listenersInitialized = false;
 
 export function setScoreboardData({ userPoints, badges, completedChores }) {
   _userPoints = userPoints;
@@ -89,24 +88,27 @@ export async function resetScoreboard() {
   return { success: true };
 }
 
-export function setupScoreboardListeners() {
-  if (listenersInitialized) return;
-  listenersInitialized = true;
+function handleResetClick() {
+  if (confirm('Are you sure you want to reset the scoreboard?')) {
+    resetScoreboard();
+  }
+}
 
+function handleSortChange(e) {
+  _sortBy = e.target.value;
+  renderScoreboard();
+}
+
+export function setupScoreboardListeners() {
   const resetBtn = document.getElementById('resetScoreboardBtn');
-  if (resetBtn) {
-    resetBtn.addEventListener('click', () => {
-      if (confirm('Are you sure you want to reset the scoreboard?')) {
-        resetScoreboard();
-      }
-    });
+  if (resetBtn && !resetBtn.dataset.bound) {
+    resetBtn.addEventListener('click', handleResetClick);
+    resetBtn.dataset.bound = 'true';
   }
 
   const sortSelect = document.getElementById('scoreSortBy');
-  if (sortSelect) {
-    sortSelect.addEventListener('change', () => {
-      _sortBy = sortSelect.value;
-      renderScoreboard();
-    });
+  if (sortSelect && !sortSelect.dataset.bound) {
+    sortSelect.addEventListener('change', handleSortChange);
+    sortSelect.dataset.bound = 'true';
   }
 }

--- a/storage.js
+++ b/storage.js
@@ -29,7 +29,7 @@ let supabaseEnabled = true;
 export let supabase;
 
 if (!supabaseUrl || !supabaseKey) {
-  alert('Supabase configuration missing. Please set SUPABASE_URL and SUPABASE_KEY in config.js');
+  showAlert('Supabase configuration missing. Please set SUPABASE_URL and SUPABASE_KEY in config.js');
   supabaseEnabled = false;
 } else {
   supabase = window.supabase


### PR DESCRIPTION
## Summary
- ensure scoreboard reset button adds listeners only once to avoid repeated confirmations
- replace browser alerts with in-app `showAlert` across auth, calendar, and storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e282473d48325beb4cecd9159e3bc