### PR TITLE
fix: handle missing question input

### DIFF
--- a/qa.js
+++ b/qa.js
@@ -102,7 +102,7 @@ export function renderQA(filterText = '') {
 function setupQAListeners() {
   if (askBtn) {
     askBtn.addEventListener('click', () => {
-      const q = newQuestionInput?.value.trim();
+      const q = (newQuestionInput?.value || '').trim();
       if (!q) {
         showAlert('Please enter your question.');
         return;


### PR DESCRIPTION
## Summary
- avoid errors when question input is absent

## Testing
- `node -e "// stubs for window/document/localStorage
global.window = { SUPABASE_URL:'', SUPABASE_KEY:'', DISABLE_SUPABASE_ALERT:true };
global.document = { getElementById: () => null };
global.localStorage = { getItem: ()=>null, setItem:()=>{} };
import('./qa.js').then(({setupQA})=>{
  const askBtn={handler:null,addEventListener(ev,cb){if(ev==='click')this.handler=cb;}};
  // with input
  setupQA({qaListRef:[], askBtnRef:askBtn, newQuestionInputRef:{value:'hi'}, adminUsersRef:[], questionOnlyUsersRef:[]});
  try { askBtn.handler(); console.log('Test with input: no error'); } catch (e) { console.error('Error with input', e); }
  // without input
  setupQA({qaListRef:[], askBtnRef:askBtn, newQuestionInputRef:null, adminUsersRef:[], questionOnlyUsersRef:[]});
  try { askBtn.handler(); console.log('Test without input: no error'); } catch (e) { console.error('Error without input', e); }
}).catch(e=>console.error('Import error', e));"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e4e23c6c48325a2a426adb915571a