### PR TITLE
Fix arrow-key focus cycling in navigation tabs

### DIFF
--- a/navigation.js
+++ b/navigation.js
@@ -56,11 +56,11 @@ export function setupTabListeners() {
       tab.addEventListener('keydown', (e) => {
         if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
           e.preventDefault();
-          const next = (i + 1) % sidebarTabs.length;
+          const next = (i + 1) % list.length;
           list[next].focus();
         } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
           e.preventDefault();
-          const prev = (i - 1 + sidebarTabs.length) % sidebarTabs.length;
+          const prev = (i - 1 + list.length) % list.length;
           list[prev].focus();
         } else if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();


### PR DESCRIPTION
## Summary
- use the current tab list length when moving focus with arrow keys

## Testing
- `npm test`
- simulated arrow-key navigation with jsdom (sidebar and bottom nav wrap correctly)


------
https://chatgpt.com/codex/tasks/task_e_688e51189fe483258d33538d351266b4