### PR TITLE
Make bottom nav buttons flex

### DIFF
--- a/style.css
+++ b/style.css
@@ -1382,7 +1382,7 @@ nav.bottom-nav {
   scrollbar-width: none;
 }
 nav.bottom-nav button {
-  flex: 0 0 72px;
+  flex: 1 0 60px;
   padding: 0.6rem 0.4rem;
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- make bottom navigation buttons flexible at 60px

## Testing
- `npm test`
- `node test_nav.cjs` (headless Chrome at 320px viewport)

------
https://chatgpt.com/codex/tasks/task_e_688e767ea1cc8325bdf363b196234d99