### PR TITLE
Initialize data load and enhance accessibility

### DIFF
--- a/index.dev.html
+++ b/index.dev.html
@@ -86,8 +86,8 @@
       <img id="wallPhotoPreview" class="wall-photo-preview" alt="Selected photo preview" hidden>
       <div id="pollFields" class="poll-fields" hidden>
         <div id="pollOptions" class="poll-options-edit">
-          <input type="text" class="poll-option-input" placeholder="Option 1">
-          <input type="text" class="poll-option-input" placeholder="Option 2">
+          <input type="text" class="poll-option-input" placeholder="Option 1" aria-label="Poll option 1">
+          <input type="text" class="poll-option-input" placeholder="Option 2" aria-label="Poll option 2">
         </div>
         <button type="button" id="addPollOptionBtn" aria-label="Add poll option">Add Option</button>
         <label class="poll-multiple-label"><input type="checkbox" id="pollMultiple"> Allow multiple selections</label>

--- a/index.html
+++ b/index.html
@@ -89,8 +89,8 @@
       <img id="wallPhotoPreview" class="wall-photo-preview" alt="Selected photo preview" hidden>
       <div id="pollFields" class="poll-fields" hidden>
         <div id="pollOptions" class="poll-options-edit">
-          <input type="text" class="poll-option-input" placeholder="Option 1">
-          <input type="text" class="poll-option-input" placeholder="Option 2">
+          <input type="text" class="poll-option-input" placeholder="Option 1" aria-label="Poll option 1">
+          <input type="text" class="poll-option-input" placeholder="Option 2" aria-label="Poll option 2">
         </div>
         <button type="button" id="addPollOptionBtn" aria-label="Add poll option">Add Option</button>
         <label class="poll-multiple-label"><input type="checkbox" id="pollMultiple"> Allow multiple selections</label>

--- a/main.js
+++ b/main.js
@@ -132,3 +132,6 @@ export async function main() {
 
 }
 
+
+// Initialize the application
+main();

--- a/navigation.js
+++ b/navigation.js
@@ -84,10 +84,22 @@ export function setupSidebarToggle() {
     overlay.classList.toggle('visible', isOpen);
     if (floatBtn) floatBtn.setAttribute('aria-expanded', isOpen);
     if (hamburgerBtn) hamburgerBtn.setAttribute('aria-expanded', isOpen);
+    if (isOpen) {
+      const active = sidebar.querySelector('li.active');
+      if (active) active.focus();
+    } else {
+      const trigger = floatBtn || hamburgerBtn;
+      if (trigger) trigger.focus();
+    }
   }
 
   [floatBtn, hamburgerBtn].forEach(btn => {
     if (btn) btn.addEventListener('click', toggle);
   });
   overlay.addEventListener('click', toggle);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && sidebar.classList.contains('open')) {
+      toggle();
+    }
+  });
 }

--- a/notifications.js
+++ b/notifications.js
@@ -10,6 +10,7 @@ export async function initNotifications() {
       console.warn('SW registration failed', e);
     }
   }
+  requestPermission();
 }
 
 export function requestPermission() {

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
 */
 :root {
   --color-primary: #1D4E89;   /* brand blue */
-  --color-secondary: #F3B44C; /* brand yellow */
+  --color-secondary: #B8860B; /* accessible yellow */
   --color-accent: var(--color-secondary);
   --color-background: #fefefe;
   --color-card: #ffffff;
@@ -102,7 +102,7 @@ textarea {
 
 input::placeholder,
 textarea::placeholder {
-  color: #888;
+  color: #666;
 }
 
 /* Containers */

--- a/wall.js
+++ b/wall.js
@@ -296,11 +296,18 @@ export function setupWallListeners() {
       const input = document.createElement('input');
       input.type = 'text';
       input.className = 'poll-option-input';
-      input.placeholder = `Option ${pollOptionsContainer.children.length + 1}`;
+      const idx = pollOptionsContainer.children.length + 1;
+      input.placeholder = `Option ${idx}`;
+      input.setAttribute('aria-label', `Poll option ${idx}`);
       input.addEventListener('input', updatePostBtnState);
       pollOptionsContainer.appendChild(input);
     });
-    Array.from(pollOptionsContainer.querySelectorAll('input')).forEach(inp => inp.addEventListener('input', updatePostBtnState));
+    Array.from(pollOptionsContainer.querySelectorAll('input')).forEach((inp, i) => {
+      inp.addEventListener('input', updatePostBtnState);
+      if (!inp.hasAttribute('aria-label')) {
+        inp.setAttribute('aria-label', `Poll option ${i + 1}`);
+      }
+    });
   }
 
   if (newWallPostInput) {


### PR DESCRIPTION
## Summary
- call `main()` so `loadAllData()` runs at startup
- improve accessibility: aria labels, keyboard-friendly sidebar, higher contrast colors
- request notification permission during service worker setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e7850854c83259304cfa8b7c0fc53